### PR TITLE
Use "promises-aplus" keyword for npm.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "keywords": [
     "promises",
     "promises-A",
-    "promises-A-plus",
+    "promises-aplus",
     "async",
     "cancel",
     "progress"


### PR DESCRIPTION
See https://github.com/promises-aplus/promises-spec/commit/dac2212d4e5b60a80f3b7cfe418464e601e2efb8.

I've already updated the other packages that used `"promises-a-plus"`, and next time they get published they'll be fixed too.
