### PR TITLE
Feature/listener unregistration

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,11 +42,21 @@ function token(data) {
   exports.onCancelled = onCancelled;
   function onCancelled(cb) {
     if (isCancelled()) {
-      setTimeout(function () {
+      var listener = function () {
         cb(data.reason);
-      }, 0);
+      }
+      var timeout = setTimeout(listener, 0);
+      return function () {
+        clearTimeout(timeout)
+      }
     } else {
       data.listeners.push(cb);
+      return function () {
+        var index = data.listeners.indexOf(cb)
+        if (index > -1) {
+          data.listeners.splice(index, 1)
+        }
+      }
     }
   }
   return exports;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "devDependencies": {
     "mocha": "~3.2.0",
     "better-assert": "~1.0",
-    "promise": "~7.1.1",
-    "mocha-as-promised": "~2.0.0"
+    "promise": "~7.1.1"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -76,6 +76,41 @@ describe('Cancelling with a token', function () {
         clearTimeout(timeout);
       });
   });
+
+  it('does not call an unregistered cancellation listener', function (callback) {
+    var source = tokenSource();
+    var timeout = setTimeout(callback, 100)
+    var listener = function () {
+      callback(new Error('Should not have been called'))
+    }
+    var unregister = source.token.onCancelled(listener)
+    unregister()
+    source.cancel()
+  })
+
+  it('does not call a cancellation listener unregistered between ' +
+      'cancellation and async listener calls', function (callback) {
+    var source = tokenSource();
+    var timeout = setTimeout(callback, 100)
+    var listener = function () {
+      callback(new Error('Should not have been called'))
+    }
+    var unregister = source.token.onCancelled(listener)
+    source.cancel()
+    unregister()
+  })
+
+  it('does not call a cancellation listener registered and unregistered between ' +
+      'cancellation and async listener calls', function (callback) {
+    var source = tokenSource();
+    var timeout = setTimeout(callback, 100)
+    var listener = function () {
+      callback(new Error('Should not have been called'))
+    }
+    source.cancel()
+    var unregister = source.token.onCancelled(listener)
+    unregister()
+  })
 });
 
 describe('Polling for cancellation', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -15,7 +15,7 @@ function delay2(timeout, cancellationToken) {
   return promise(function (resolve, reject) {
     setTimeout(resolve, timeout);
     setTimeout(function () {
-      if (cancellationToken.isCancelled()) 
+      if (cancellationToken.isCancelled())
         reject(new Error('Operation Cancelled'));
     }, timeout / 4);
   });

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,3 @@
-require('mocha-as-promised')();
 var Promise = require('promise');
 var tokenSource = require('../');
 var assert = require('better-assert');

--- a/test/test.js
+++ b/test/test.js
@@ -1,25 +1,24 @@
 require('mocha-as-promised')();
-var promise = require('promise');
+var Promise = require('promise');
 var tokenSource = require('../');
 var assert = require('better-assert');
 
 function delay(timeout, cancellationToken) {
   cancellationToken = cancellationToken || tokenSource.empty;
-  return promise(function (resolve, reject) {
+  return new Promise(function (resolve, reject) {
     setTimeout(resolve, timeout);
     cancellationToken.onCancelled(reject);
   });
 }
 function delay2(timeout, cancellationToken) {
   cancellationToken = cancellationToken || tokenSource.empty;
-  return promise(function (resolve, reject) {
+  return new Promise(function (resolve, reject) {
     setTimeout(resolve, timeout);
     setTimeout(function () {
       if (cancellationToken.isCancelled())
         reject(new Error('Operation Cancelled'));
     }, timeout / 4);
   });
-  return def.promise;
 }
 function delay3(timeout, cancellationToken) {
   cancellationToken = cancellationToken || tokenSource.empty;


### PR DESCRIPTION
There is currently no way to unregister `onCancelled()` listeners.

This makes `onCancelled()` return a function which unregisters the previously registered listener.

```javascript
const source = tokenSource()
var unregister = source.token.onCancelled(listener)
unregister()
source.cancel()
// The `listener` is not invoked.
```